### PR TITLE
Update config.yaml

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -49,6 +49,8 @@ teams:
 - name: identity-credential-admins
   maintainers:
   - davidz25
+  members:
+  - troykensinger
 - name: identity-credential-maintainers
   maintainers:
   - davidz25
@@ -60,6 +62,7 @@ teams:
   - sethmoo
   - sorotokin
   - suzannajiwani
+  - troykensinger
   - kdeus
   - hzawawy
   - TheCoryBarker


### PR DESCRIPTION
Adding Troy Kensinger (@troykensinger) to OWF Labs as owner and maintainer of [identity-credential](https://github.com/openwallet-foundation-labs/identity-credential/tree/main/wallet/src/main/res) (aka Multipaz).