### PR TITLE
Adding Open Mobile Hub contributors to Multipaz Repo

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -66,6 +66,10 @@ teams:
   - kdeus
   - hzawawy
   - TheCoryBarker
+  - hanluOMH
+  - itsme291
+  - VishnuSanal
+  - dzuluaga
 - name: lcw-maintainers
   maintainers:
   - alexfigtree


### PR DESCRIPTION
Members of the Linux Foundation's Open Mobile Hub project looking to contribute to Multipaz. As such, I'm adding them as maintainers.

hanluOMH
itsme291
VishnuSanal
dzuluaga

Signed-off-by: Troy Kensinger <troykensinger@gmail.com>