### PR TITLE
Update sd-jwt-rust-maintainers team

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -130,6 +130,9 @@ teams:
   - jovfer
   members:
   - Abdulbois
+  - ashcherbakov
+  - AlexanderShenshin
+  - Vanderkast
 - name: sd-jwt-vc-dm-maintainers
   maintainers:
   - lukasjhan


### PR DESCRIPTION
I'd like to request updates for sd-jwt-rust-maintainers team (see [repo](https://github.com/openwallet-foundation-labs/sd-jwt-rust)).

The project is maintained by DSR team and there is a need to actualize maintainers list from our side.